### PR TITLE
Hyprland tweaks

### DIFF
--- a/hyprland/.config/hypr/hypridle-relaxed.conf
+++ b/hyprland/.config/hypr/hypridle-relaxed.conf
@@ -1,0 +1,26 @@
+general {
+    lock_cmd = pidof hyprlock || hyprlock
+    before_sleep_cmd = loginctl lock-session    # lock before suspend
+    after_sleep_cmd = hyprctl dispatch dpms on
+}
+
+# Relaxed profile, toggled via Super+I (see scripts/idle-toggle)
+
+# Turn off screen
+listener {
+    timeout = 1200
+    on-timeout = hyprctl dispatch dpms off
+    on-resume = hyprctl dispatch dpms on
+}
+
+# Lock the screen
+listener {
+    timeout = 2700
+    on-timeout = loginctl lock-session
+}
+
+# Suspend the system
+listener {
+    timeout = 3600
+    on-timeout = loginctl suspend
+}

--- a/hyprland/.config/hypr/hyprland.conf
+++ b/hyprland/.config/hypr/hyprland.conf
@@ -210,6 +210,26 @@ device {
 # See https://wiki.hypr.land/Configuring/Keywords/
 $mainMod = SUPER # Sets "Windows" key as main modifier
 
+# Swallow F24 emitted by kanata's home row mod workaround so it never reaches apps.
+# Home row mods are: lsft/rsft, lalt/ralt, lmet/rmet, lctl/rctl — covers all 16
+# modifier combinations (2^4) so that MOD+F24 is also consumed at the compositor.
+bind =            , F24, event, noop
+bind = SHIFT      , F24, event, noop
+bind = ALT        , F24, event, noop
+bind = SUPER      , F24, event, noop
+bind = CTRL       , F24, event, noop
+bind = SHIFT ALT  , F24, event, noop
+bind = SHIFT SUPER, F24, event, noop
+bind = SHIFT CTRL , F24, event, noop
+bind = ALT SUPER  , F24, event, noop
+bind = ALT CTRL   , F24, event, noop
+bind = SUPER CTRL , F24, event, noop
+bind = SHIFT ALT SUPER      , F24, event, noop
+bind = SHIFT ALT CTRL       , F24, event, noop
+bind = SHIFT SUPER CTRL     , F24, event, noop
+bind = ALT SUPER CTRL       , F24, event, noop
+bind = SHIFT ALT SUPER CTRL , F24, event, noop
+
 # Example binds, see https://wiki.hypr.land/Configuring/Binds/ for more
 bind = $mainMod, Return, exec, $terminal
 bind = $mainMod SHIFT, C, killactive,

--- a/hyprland/.config/hypr/hyprland.conf
+++ b/hyprland/.config/hypr/hyprland.conf
@@ -114,7 +114,7 @@ decoration {
 }
 
 animations {
-    enabled = yes, please :)
+    enabled = 1
 
     # Default curves, see https://wiki.hypr.land/Configuring/Animations/#curves
     #        NAME,           X0,   Y0,   X1,   Y1
@@ -167,9 +167,8 @@ master {
 
 misc {
     font_family = Inconsolata Nerd Font
-    force_default_wallpaper = -1 # Set to 0 or 1 to disable the anime mascot wallpapers
+    force_default_wallpaper = 0 # Set to 0 or 1 to disable the anime mascot wallpapers
     disable_hyprland_logo = true # If true disables the random hyprland logo / anime girl background. :(
-    vfr = true
 }
 
 

--- a/hyprland/.config/hypr/hyprland.conf
+++ b/hyprland/.config/hypr/hyprland.conf
@@ -155,9 +155,10 @@ windowrule = rounding 0, match:float false, match:workspace w[tv1]
 windowrule = border_size 0, match:float false, match:workspace f[1]
 windowrule = rounding 0, match:float false, match:workspace f[1]
 
+# Applies when switching to dwindle via mainMod+CTRL+SHIFT+SPACE
+# (pseudotile option was removed in Hyprland 0.55; the pseudo dispatcher remains)
 dwindle {
-    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
-    preserve_split = true # You probably want this
+    preserve_split = true
 }
 
 master {
@@ -238,7 +239,9 @@ bind = $mainMod, E, exec, $fileManager
 bind = $mainMod, V, togglefloating,
 bind = $mainMod, SPACE, exec, $menu
 bind = $mainMod, P, pseudo, # dwindle
-bind = $mainMod_SHIFT, J, togglesplit, # dwindle
+bind = $mainMod SHIFT, J, layoutmsg, togglesplit # dwindle
+bind = $mainMod CTRL, SPACE, exec, hyprctl keyword general:layout master
+bind = $mainMod CTRL SHIFT, SPACE, exec, hyprctl keyword general:layout dwindle
 
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l

--- a/hyprland/.config/hypr/hyprland.conf
+++ b/hyprland/.config/hypr/hyprland.conf
@@ -22,15 +22,15 @@ $menu = wofi --show run,drun
 ### AUTOSTART ###
 #################
 
-exec-once = pipewire &
-exec-once = dunst &
-exec-once = waybar &
-exec-once = hyprpaper &
-exec-once = hypridle &
-exec-once = /usr/lib/hyprpolkitagent/hyprpolkitagent &
+exec-once = pipewire
+exec-once = dunst
+exec-once = bash -c 'until [ -S "$XDG_RUNTIME_DIR/pulse/native" ]; do sleep 0.25; done; waybar'
+exec-once = hyprpaper
+exec-once = hypridle
+exec-once = /usr/lib/hyprpolkitagent/hyprpolkitagent
 
 # SSH Agent setup
-exec-once = runsvdir $HOME/.config/runit/runsvdir/current &
+exec-once = runsvdir $HOME/.config/runit/runsvdir/current
 exec-once = $HOME/.config/scripts/ssh-load-keys
 
 #############################

--- a/hyprland/.config/hypr/hyprland.conf
+++ b/hyprland/.config/hypr/hyprland.conf
@@ -6,7 +6,16 @@
 ### MONITORS ###
 ################
 
-monitor=,highres,auto,1
+# Monitors are matched by EDID description (stable across ports/replugs),
+# not by DP-N names. Confirm strings with `hyprctl monitors all` when docked.
+monitor = eDP-1, highres, auto, 1.175
+monitor = desc:Odyssey G81SF, 3840x2160@240, auto, 1.25, vrr, 1
+# TODO fill in desc: for these next time they're connected:
+#monitor = desc:???, 2560x1080@74.99, auto, 1, vrr, 1
+#monitor = desc:???, highres, 0x0, 1, transform, 3
+#monitor = eDP-1, disable
+# Fallback for unknown monitors
+monitor = , highres, auto, 1, vrr, 1
 
 
 ###################
@@ -50,9 +59,8 @@ env = GRIM_DEFAULT_DIR,$HOME/Pictures/screenshots
 env = GTK_THEME,Sweet-mars
 env = ICON_THEME,Papirus-Dark
 
-# Needed for proper scaling in wayland
-env = GDK_SCALE,1.175
-env = QT_SCALE_FACTOR,1.175
+# Per-monitor compositor scale is the single source of truth for scaling;
+# Wayland-native GTK/Qt follow it automatically (no GDK_SCALE/QT_SCALE_FACTOR).
 env = ELECTRON_OZONE_PLATFORM_HINT,wayland
 
 ###################

--- a/hyprland/.config/hypr/hyprland.conf
+++ b/hyprland/.config/hypr/hyprland.conf
@@ -318,6 +318,8 @@ bindl = , XF86AudioPrev, exec, playerctl previous
 # Lock and sleep
 bind = $mainMod SHIFT, L, exec, hyprlock
 bind = $mainMod SHIFT CTRL, S, exec, loginctl suspend
+# Toggle hypridle default/relaxed profile (screen off 20m, lock 45m, suspend 60m)
+bind = $mainMod, I, exec, $HOME/.config/scripts/idle-toggle
 
 # Application launch
 bind = $mainMod, W, exec, chromium

--- a/hyprland/.config/scripts/idle-toggle
+++ b/hyprland/.config/scripts/idle-toggle
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Toggle hypridle between the default and relaxed timeout profiles by
+# restarting it with the corresponding config. The running profile is
+# identifiable from hypridle's command line.
+
+RELAXED="$HOME/.config/hypr/hypridle-relaxed.conf"
+
+if pgrep -x hypridle -a | grep -q relaxed; then
+    pkill -x hypridle
+    hypridle >/dev/null 2>&1 &
+    notify-send "Idle timeouts: default" "Lock 7m, screen off 8m, suspend 10m"
+else
+    pkill -x hypridle
+    hypridle --config "$RELAXED" >/dev/null 2>&1 &
+    notify-send "Idle timeouts: relaxed" "Screen off 20m, lock 45m, suspend 60m"
+fi

--- a/linux/.config/zsh/zshrc.local
+++ b/linux/.config/zsh/zshrc.local
@@ -11,3 +11,6 @@ export PATH="$HOME/.opencode/bin:$PATH"
 
 # Go (Linux manual install; macOS uses Homebrew's go)
 export PATH="/usr/local/go/bin:$PATH"
+
+# pipx/uv user installs
+export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
  ## Summary

  Quality-of-life pass over the Hyprland setup: integrate kanata's home-row mods
  with the compositor, make session autostart deterministic, move to per-monitor
  scaling with stable monitor identity, and add an on-demand relaxed idle profile.

  ## Kanata integration

  - kanata emits F24 alongside every home-row mod tap-hold so chords always
    register; the compositor now swallows it via a no-op `event` dispatch
    (no process spawn) across all 16 modifier combinations, so apps never
    see stray F24 presses.

  ## Autostart

  - waybar raced pipewire-pulse at login and could come up without its audio
    module — it now waits for the pulse socket before launching.
  - Dropped the stray `&` from `exec-once` lines (Hyprland already detaches).

  ## Layout

  - Fixed the broken togglesplit bind (`$mainMod_SHIFT` typo + removed bare
    dispatcher) — now `Super+Shift+J` via `layoutmsg`.
  - New `Super+Ctrl+Space` / `Super+Ctrl+Shift+Space` to hot-switch
    master ⇄ dwindle at runtime.
  - Dropped `dwindle:pseudotile` (option removed in Hyprland 0.55).

  ## Scaling

  - Replaced global `GDK_SCALE`/`QT_SCALE_FACTOR` env scaling (GDK_SCALE
    silently ignores fractional values, and one global factor is wrong on
    mixed-DPI setups) with per-monitor compositor scale.
  - eDP-1 at 1.175 → exact logical 1920×1280 on the Framework panel.
  - External monitors matched by `desc:` (EDID) instead of `DP-N`, so rules
    survive replugging and port changes; VRR enabled, fallback rule for
    unknown displays.

  ## Idle profiles

  - `Super+I` toggles hypridle between the default profile (lock 7m /
    screen off 8m / suspend 10m) and a relaxed one (screen off 20m /
    lock 45m / suspend 60m) by restarting it with an alternate config.
    Active profile is visible from hypridle's command line.

  ## Validation

  Tested live on the Framework laptop: config reloads with no `configerrors`,
  F24 no-op binds active, idle toggle verified in both directions, panel
  running at 1.175 compositor scale.

  ## Out of scope / follow-ups

  - Fill in `desc:` strings for the remaining external monitors next time
    they're connected (`hyprctl monitors all`).
  - Check Xwayland apps at fractional scale; add
    `xwayland { force_zero_scaling = true }` if blurry.